### PR TITLE
Add sample tests and pytest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 python -m app.main
 ```
 
+### 6. 테스트 실행
+```bash
+pytest -v tests/
+```
+
 ## 프로젝트 구조
 
 ```

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -111,7 +111,7 @@ Select from menu:
 1. **Full Application**: Runs both GUI and API server
 2. **API Only**: Runs just the backend API server
 3. **Development Mode**: Enables hot reload for development
-4. **Run Tests**: Execute test suite
+4. **Run Tests**: `pytest -v tests/`
 5. **Database Reset**: Clear and reinitialize database
 
 ### Troubleshooting

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:asyncio

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health_endpoint():
+    res = client.get("/health")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "healthy"
+
+
+def test_reception_departments():
+    res = client.get("/api/reception/departments")
+    assert res.status_code == 200
+    departments = res.json()
+    assert isinstance(departments, list)
+    assert departments


### PR DESCRIPTION
## Summary
- add simple pytest configuration
- add example tests for `/health` and reception endpoints
- document how to run the test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68419f1c01f4832c85e20a7457f9987d