### PR TITLE
Fix scheduler timeout mapping

### DIFF
--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -51,10 +51,10 @@ class KioskScheduler:
     ) -> Job:
         """Add session timeout job"""
         job_id = f"session_timeout_{session_id}"
-        
+
         # Remove existing timeout for this session
-        if job_id in self._session_timers:
-            self.scheduler.remove_job(job_id)
+        if session_id in self._session_timers:
+            self.scheduler.remove_job(self._session_timers[session_id].id)
         
         # Add new timeout job
         job = self.scheduler.add_job(
@@ -74,17 +74,16 @@ class KioskScheduler:
     
     def reset_session_timeout(self, session_id: str):
         """Reset session timeout by rescheduling"""
-        job_id = f"session_timeout_{session_id}"
-        if job_id in self._session_timers:
-            job = self._session_timers[job_id]
+        if session_id in self._session_timers:
+            job = self._session_timers[session_id]
             job.reschedule('interval', seconds=job.trigger.interval.total_seconds())
             logger.info(f"Session timeout reset for {session_id}")
     
     def cancel_session_timeout(self, session_id: str):
         """Cancel session timeout"""
-        job_id = f"session_timeout_{session_id}"
-        if job_id in self._session_timers:
-            self.scheduler.remove_job(job_id)
+        if session_id in self._session_timers:
+            job = self._session_timers[session_id]
+            self.scheduler.remove_job(job.id)
             del self._session_timers[session_id]
             logger.info(f"Session timeout cancelled for {session_id}")
     

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,52 @@
+import importlib.util
+import os
+import sys
+import pytest
+
+# Load scheduler module without importing the full package to avoid heavy
+# dependencies during tests
+MODULE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "app", "core", "scheduler.py"))
+spec = importlib.util.spec_from_file_location("scheduler", MODULE_PATH)
+scheduler_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scheduler_module)
+KioskScheduler = scheduler_module.KioskScheduler
+
+
+def dummy_callback():
+    return "done"
+
+
+def test_add_reset_cancel_session_timeout():
+    scheduler = KioskScheduler()
+    scheduler.start()
+
+    # Add session timeout
+    job1 = scheduler.add_session_timeout("s1", timeout_seconds=10, callback=dummy_callback)
+    assert "s1" in scheduler._session_timers
+    assert scheduler._session_timers["s1"] == job1
+
+    # Reset should keep same job object and reschedule
+    scheduler.reset_session_timeout("s1")
+    assert scheduler._session_timers["s1"] == job1
+
+    # Cancel should remove job
+    scheduler.cancel_session_timeout("s1")
+    assert "s1" not in scheduler._session_timers
+    assert scheduler.scheduler.get_job(job1.id) is None
+
+    scheduler.shutdown()
+
+
+def test_re_add_session_timeout_replaces_job():
+    scheduler = KioskScheduler()
+    scheduler.start()
+
+    job1 = scheduler.add_session_timeout("s2", timeout_seconds=5, callback=dummy_callback)
+    job2 = scheduler.add_session_timeout("s2", timeout_seconds=5, callback=dummy_callback)
+
+    # Job should be replaced
+    assert job2 is not job1
+    assert scheduler.scheduler.get_job(job1.id) is job2
+    assert scheduler._session_timers["s2"] == job2
+
+    scheduler.shutdown()


### PR DESCRIPTION
## Summary
- fix internal `_session_timers` usage
- add unit tests for scheduler timeouts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a09f1b30832c9540ea2725e58145